### PR TITLE
docs(repo): add hygiene files and contributor guidelines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.rs]
+indent_size = 4
+
+[*.{ts,tsx,js,jsx,json,css,scss,md,yml,yaml}]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Rust
+target/
+**/target/
+
+# Node / frontend
+node_modules/
+dist/
+.vite/
+
+# Tauri generated/build output
+src-tauri/target/
+src-tauri/gen/
+
+# Env files
+.env
+.env.local
+.env.*
+!.env.example
+
+# Databases
+*.db
+*.db-journal
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE/editor
+.idea/
+.vscode/
+
+# Build/install artifacts
+*.dmg
+*.app
+*.AppImage
+*.msi
+*.deb
+*.exe

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# BusyDev Contributor Context
+
+## Project Summary
+
+BusyDev is an open-source desktop app for managing multiple AI coding agent sessions across repos and branches in parallel.
+
+## Stack
+
+- Backend: Rust (Tauri 2)
+- Frontend: Vite + React + TypeScript
+- State: Zustand
+- Terminal: xterm.js + portable-pty
+- Persistence: SQLite (rusqlite)
+
+## Primary Commands
+
+- Install dependencies: `npm install`
+- Run app in dev: `cargo tauri dev`
+- Build app: `cargo tauri build`
+- Frontend lint: `npm run lint`
+- Rust lint: `cargo clippy -- -D warnings`
+- Rust tests: `cargo test`
+
+## Directory Shape
+
+- `src-tauri/`: Rust backend and Tauri integration
+- `src/`: React frontend
+- `src/components/`: UI components
+- `src/stores/`: Zustand stores
+- `src/hooks/`: Tauri invoke/listen hooks
+
+## Conventions
+
+- Rust naming: `snake_case` for variables/functions, `CamelCase` for types
+- TypeScript naming: `camelCase` for variables/functions, `PascalCase` for components/types
+- Keep IPC payloads explicit and typed
+- Favor small, composable modules over large files
+
+## Commit Message Format
+
+Use conventional commits:
+
+- `feat(scope): short description`
+- `fix(scope): short description`
+- `refactor(scope): short description`
+- `docs(scope): short description`
+- `test(scope): short description`
+- `chore(scope): short description`
+
+Suggested scopes: `agent`, `git`, `terminal`, `ui`, `db`, `notifications`, `settings`, `build`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to BusyDev
+
+Thanks for contributing. This project is being built in public, and small, focused changes are preferred.
+
+## Prerequisites
+
+- Rust toolchain (`rustc`, `cargo`)
+- Node.js + npm
+- Tauri CLI v2 (`cargo install tauri-cli --version '^2'`)
+- macOS command line tools (`xcode-select --install`)
+
+## Local Development
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run in development:
+
+```bash
+cargo tauri dev
+```
+
+Build:
+
+```bash
+cargo tauri build
+```
+
+## Branch Naming
+
+BusyDev uses [Conventional Branch](https://conventional-branch.github.io/) naming.
+
+Rules:
+
+- Use format: `<type>/<short-description>`
+- Use lowercase and hyphen-separated description
+- Keep branch names descriptive and concise
+- Do not include private Linear ticket IDs in branch names
+
+Examples:
+
+- `feat/workspace-crud`
+- `fix/terminal-resize-event-order`
+- `chore/repo-hygiene-docs-foundation`
+
+## Commit Messages
+
+Use conventional commits:
+
+- `feat(scope): description`
+- `fix(scope): description`
+- `refactor(scope): description`
+- `docs(scope): description`
+- `test(scope): description`
+- `ci(scope): description`
+- `chore(scope): description`
+
+Suggested scopes: `agent`, `git`, `terminal`, `ui`, `db`, `notifications`, `settings`, `build`, `docs`.
+
+## Pull Requests
+
+- Keep PRs scoped to one coherent change set
+- Include what changed, why, and how it was validated
+- Link related backlog items in PR description (without requiring ticket IDs in branch names)
+- Prefer squash merges unless maintainers request otherwise
+
+## CI/CD and Versioning
+
+BusyDev will use automated versioning and release pipelines.
+
+Current policy direction:
+
+- Keep `package.json`, `Cargo.toml`, and `tauri.conf.json` versions synchronized
+- Enforce branch protection with required checks
+- Expand CI to include lint, test, and build verification
+- Automate release/tag flow with version bump + changelog generation
+
+If a change affects release/version behavior, document it explicitly in the PR description.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 BusyDev contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,78 @@
-# busydev
-your coding agent workspace
+# BusyDev
+
+BusyDev is an open-source desktop app for running multiple AI coding agent sessions across repos and branches at the same time.
+
+## Why BusyDev
+
+If you use CLI agents (Codex, Claude Code, Aider, etc.) across several repos, you end up juggling terminal tabs, losing context, and missing when an agent needs attention. BusyDev gives you one place to coordinate all of that.
+
+## What It Does
+
+- Manage multiple projects and agent workspaces in one app
+- Create isolated git worktrees per workspace automatically
+- View agent chat output with status and usage context
+- Review code changes in a built-in diff viewer
+- Run integrated terminal tabs per workspace
+- Get attention signals via in-app notifications and tray badge
+- Stay LLM-agnostic through an adapter-based agent system
+
+## Current Status
+
+BusyDev is in active development. The architecture and backlog are defined, and foundational implementation is underway.
+
+## Tech Stack
+
+- Rust + Tauri 2 (desktop backend/runtime)
+- React + TypeScript + Vite (frontend)
+- Zustand (state management)
+- SQLite via `rusqlite` (persistence)
+- `portable-pty` + `xterm.js` (terminal integration)
+
+## Getting Started (Dev)
+
+Prerequisites:
+
+- Rust toolchain
+- Node.js + npm
+- Tauri 2 CLI (`cargo install tauri-cli --version '^2'`)
+- macOS command line tools (`xcode-select --install`)
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run in development:
+
+```bash
+cargo tauri dev
+```
+
+Build:
+
+```bash
+cargo tauri build
+```
+
+## Roadmap (High Level)
+
+1. Repo health and project scaffolding
+2. Data model + SQLite migrations
+3. Three-panel UI shell
+4. Git integration (worktrees, diffs, file watching)
+5. Terminal manager + xterm integration
+6. Agent manager + adapters (Codex/Claude)
+7. Chat/diff UX polish
+8. Notifications and settings
+
+## Contributing
+
+Contributions are welcome. We are building this in public and keeping the architecture modular so new contributors can pick up focused tickets quickly.
+
+Please open an issue or pick from the BusyDev backlog in Linear, then submit a PR with a clear scope.
+For workflow and branch conventions, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
This PR establishes baseline repository hygiene and contributor guidance for `busydev`.

## What Changed
- Added `.editorconfig` for consistent editor behavior.
- Added `.gitignore` with common development/build ignores.
- Added `LICENSE` (MIT).
- Added `CONTRIBUTING.md` with contribution workflow and expectations.
- Added `CLAUDE.md` with AI-agent collaboration guidance.
- Updated `README.md` with project orientation and contributor-facing documentation links.

## Why
These changes create a clean, consistent foundation for future development and make onboarding and contribution expectations explicit.

## Validation
- Documentation/repo-configuration only.
- No runtime code paths changed.
- No behavioral changes expected.

## Follow-ups
- Add GitHub issue and pull request templates.
- Add CI checks for lint/format/test gates.
