### PR TITLE
docs(branding): rename BusyDev to busydev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
-# BusyDev Contributor Context
+# busydev Contributor Context
 
 ## Project Summary
 
-BusyDev is an open-source desktop app for managing multiple AI coding agent sessions across repos and branches in parallel.
+busydev is an open-source desktop app for managing multiple AI coding agent sessions across repos and branches in parallel.
 
 ## Stack
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to BusyDev
+# Contributing to busydev
 
 Thanks for contributing. This project is being built in public, and small, focused changes are preferred.
 
@@ -31,7 +31,7 @@ cargo tauri build
 
 ## Branch Naming
 
-BusyDev uses [Conventional Branch](https://conventional-branch.github.io/) naming.
+busydev uses [Conventional Branch](https://conventional-branch.github.io/) naming.
 
 Rules:
 
@@ -69,7 +69,7 @@ Suggested scopes: `agent`, `git`, `terminal`, `ui`, `db`, `notifications`, `sett
 
 ## CI/CD and Versioning
 
-BusyDev will use automated versioning and release pipelines.
+busydev will use automated versioning and release pipelines.
 
 Current policy direction:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 BusyDev contributors
+Copyright (c) 2026 busydev contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# BusyDev
+# busydev
 
-BusyDev is an open-source desktop app for running multiple AI coding agent sessions across repos and branches at the same time.
+busydev is an open-source desktop app for running multiple AI coding agent sessions across repos and branches at the same time.
 
-## Why BusyDev
+## Why busydev
 
-If you use CLI agents (Codex, Claude Code, Aider, etc.) across several repos, you end up juggling terminal tabs, losing context, and missing when an agent needs attention. BusyDev gives you one place to coordinate all of that.
+If you use CLI agents (Codex, Claude Code, Aider, etc.) across several repos, you end up juggling terminal tabs, losing context, and missing when an agent needs attention. busydev gives you one place to coordinate all of that.
 
 ## What It Does
 
@@ -18,7 +18,7 @@ If you use CLI agents (Codex, Claude Code, Aider, etc.) across several repos, yo
 
 ## Current Status
 
-BusyDev is in active development. The architecture and backlog are defined, and foundational implementation is underway.
+busydev is in active development. The architecture and backlog are defined, and foundational implementation is underway.
 
 ## Tech Stack
 
@@ -70,7 +70,7 @@ cargo tauri build
 
 Contributions are welcome. We are building this in public and keeping the architecture modular so new contributors can pick up focused tickets quickly.
 
-Please open an issue or pick from the BusyDev backlog in Linear, then submit a PR with a clear scope.
+Please open an issue or pick from the busydev backlog in Linear, then submit a PR with a clear scope.
 For workflow and branch conventions, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## License


### PR DESCRIPTION
## Summary
Renames project name references from  to  for consistent branding.

## Changes
- Updated README headings/body references.
- Updated CONTRIBUTING title and references.
- Updated CLAUDE contributor context title/summary.
- Updated LICENSE copyright line.

## Validation
- Documentation-only text changes.
- No runtime code paths changed.