### PR TITLE
fix(git): use unique branch names for worktree sessions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1550,8 +1550,9 @@ function App() {
       try {
         const isGit = await isGitRepo(activeProject.path);
         if (isGit) {
+          const shortId = session.id.split("-")[0];
           const slug = session.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
-          const branch = `busydev/${slug}`;
+          const branch = `busydev/${slug}-${shortId}`;
           const projectSlug = activeProject.path.replace(/\//g, "-").replace(/^-/, "");
           const wtPath = `/tmp/busydev-worktrees/${projectSlug}/${session.id}`;
           await createWorktree(activeProject.path, wtPath, branch);


### PR DESCRIPTION
## Summary
- Worktree creation was failing silently because branch names collided across sessions
- Branch name was derived from session name alone (e.g. `busydev/session-2`), which is identical every time a second session is created
- If a previous worktree/branch wasn't fully cleaned up, `git worktree add` would refuse to check out the already-used branch
- Fix: append session UUID prefix to branch name (e.g. `busydev/session-2-a3f7b1c2`) to guarantee uniqueness

## Test plan
- [ ] Create multiple sessions in a git project — each should get its own worktree
- [ ] Delete a session, create a new one with the same index — should succeed without collision
- [ ] Verify agent runs in the worktree directory, not the project root

🤖 Generated with [Claude Code](https://claude.com/claude-code)