### PR TITLE
fix(ui): clear stale event stream on session switch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1570,10 +1570,11 @@ ${contents}`);
   // Switching just resets ephemeral UI state; derived values auto-update from projects.
 
   function resetEphemeralState() {
+    // Clear stream-related state immediately to prevent stale data flash
+    setActiveTabId(null);
+    setError(null);
     setTransitioning(true);
     setTimeout(() => {
-      setActiveTabId(null);
-      setError(null);
       setPrompt("");
       setPromptHistory([]);
       setHistoryIndex(-1);


### PR DESCRIPTION
## Summary
- Fix stale event stream flash when switching/creating sessions: `activeTabId` was cleared inside a 120ms setTimeout, causing the previous session's in-flight run to briefly render in the new session. Now cleared immediately.
- Dark title bar fix (`backgroundColor: "#161616"`) is already in main since the titlebar PR — a new release build will pick it up.

## Test plan
- [ ] Create a new session while an agent is running — stream panel should be empty, not showing the previous session's events
- [ ] Switch between sessions — no flash of stale data
- [ ] Build release — title bar should be dark (#161616)

🤖 Generated with [Claude Code](https://claude.com/claude-code)